### PR TITLE
Unit tests and dependency constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor
+/.phpunit.result.cache
+/composer.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contribution Guide
+
+This contribution guide is a work-in-progress.
+
+## Getting started
+
+1. **Clone this repository**
+    ```
+    gh repo clone firevel/firestore-cache-driver # or
+    git clone https://github.com/firevel/firestore-cache-driver
+    ```
+2. **Install the dependencies**
+    ```
+    composer install
+    ```
+3. **Run the unit tests**
+   1. Using Docker
+      1. `composer run test`
+   2. Using the Firebase CLI (see below)
+      1. `firebase emulators:start`
+      2. `vendor/bin/phpunit` or `composer run test-only`
+
+## Optional: Using the Firebase CLI
+
+By default, when you run `composer run test`, Composer will spin up a Docker image
+with a Firestore emulator (this one, to be exact).
+
+If you would rather use features like the Firestore UI, you can use the [Firebase CLI][1] with the [Firestore Emulator][2].
+
+The project comes pre-packages with a `firebase.json` that will bind the emulators to the correct ports, so after
+you've set up the CLI, you can simply run `firebase emulators:start`.
+
+[1]: https://firebase.google.com/docs/cli
+[2]: https://firebase.google.com/docs/emulator-suite/install_and_configure

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,12 @@
     "scripts": {
         "test": [
             "Composer\\Config::disableProcessTimeout",
+            "docker rm --force firestore-emulator || true",
+            "docker run -d --name firestore-emulator -e \"FIRESTORE_PROJECT_ID=project-test\" -e \"PORT=8080\" -p 127.0.0.1:8081:8080 mtlynch/firestore-emulator-docker",
+            "phpunit"
+        ],
+        "test-only": [
+            "Composer\\Config::disableProcessTimeout",
             "phpunit"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,11 @@
     "type": "library",
     "license": "MIT",
     "require": {
+        "php": "^7.2 || ^8.0",
         "google/cloud-firestore": "^1.14",
-        "grpc/grpc": "^1.30"
+        "grpc/grpc": "^1.30",
+        "illuminate/contracts": "^5.8 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
         "illuminate/contracts": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },
+    "require-dev": {
+        "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0"
+    },
     "authors": [
         {
             "name": "Michael Slowik",
@@ -22,11 +25,22 @@
             "Firevel\\FirestoreCacheDriver\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\Firevel\\FirestoreCacheDriver\\": "tests/"
+        }
+    },
     "extra": {
         "laravel": {
             "providers": [
                 "Firevel\\FirestoreCacheDriver\\FirestoreCacheServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit"
+        ]
     }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,10 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8081
+    },
+    "ui": {
+      "enabled": true
+    }
+  }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,5 +25,8 @@
   <php>
     <env name="APP_KEY" value="jaiSh4noox7in8zuu0Eec3zuR0usie2n"/>
     <env name="APP_ENV" value="testing"/>
+
+    <!-- Firestore emulator -->
+    <env name="FIRESTORE_EMULATOR_HOST" value="localhost:8081" />
   </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    verbose="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <php>
+    <env name="APP_KEY" value="jaiSh4noox7in8zuu0Eec3zuR0usie2n"/>
+    <env name="APP_ENV" value="testing"/>
+  </php>
+</phpunit>

--- a/src/FirestoreCache.php
+++ b/src/FirestoreCache.php
@@ -40,9 +40,9 @@ class FirestoreCache implements Store
     /**
      * Create a new firestore cache store instance.
      *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  string  $collection
-     * @param  string  $prefix
+     * @param FirestoreClient $client
+     * @param string $collection
+     * @param string $prefix
      * @return void
      */
     public function __construct(FirestoreClient $client, $collection = 'cache', $prefix = '')
@@ -83,7 +83,7 @@ class FirestoreCache implements Store
      */
     public function expired($item)
     {
-        return $item->expiration->get()->getTimestamp() < time();
+        return $item->expiration->get() < now();
     }
 
     /**

--- a/src/FirestoreCache.php
+++ b/src/FirestoreCache.php
@@ -2,19 +2,17 @@
 
 namespace Firevel\FirestoreCacheDriver;
 
-use Carbon\Carbon;
 use DateTime;
-use Exception;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\FirestoreClient;
 use Illuminate\Cache\RetrievesMultipleKeys;
 use Illuminate\Contracts\Cache\Store;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\InteractsWithTime;
 
 class FirestoreCache implements Store
 {
-    use InteractsWithTime, RetrievesMultipleKeys;
+    use InteractsWithTime;
+    use RetrievesMultipleKeys;
 
     /**
      * Firestore client.
@@ -96,7 +94,7 @@ class FirestoreCache implements Store
     {
         $data = $this
             ->getCollection()
-            ->document($this->getPrefix().$key)
+            ->document($this->getPrefix() . $key)
             ->snapshot()
             ->data();
 
@@ -128,7 +126,7 @@ class FirestoreCache implements Store
 
         $this
             ->getCollection()
-            ->document($this->getPrefix().$key)
+            ->document($this->getPrefix() . $key)
             ->set($payload);
 
         return true;
@@ -190,7 +188,7 @@ class FirestoreCache implements Store
      */
     public function forget($key)
     {
-        $this->getCollection()->document($this->getPrefix().$key)->delete();
+        $this->getCollection()->document($this->getPrefix() . $key)->delete();
     }
 
     /**
@@ -238,7 +236,7 @@ class FirestoreCache implements Store
         return $this->prefix;
     }
 
-    /** 
+    /**
      * Get a collection reference.
      *
      * @return CollectionReference

--- a/src/FirestoreCacheServiceProvider.php
+++ b/src/FirestoreCacheServiceProvider.php
@@ -20,7 +20,7 @@ class FirestoreCacheServiceProvider extends ServiceProvider
             $store = $app['config']['cache.default'];
             return Cache::repository(
                 new FirestoreCache(
-                    new FirestoreClient,
+                    new FirestoreClient(),
                     $app['config']["cache.stores.{$store}.collection"],
                     $this->app['config']['cache.prefix']
                 )

--- a/tests/Fixtures/TestPerson.php
+++ b/tests/Fixtures/TestPerson.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Firevel\FirestoreCacheDriver\Fixtures;
+
+class TestPerson
+{
+    public $name;
+
+    protected $age;
+
+    public function __construct(string $name, int $age)
+    {
+        $this->name = $name;
+        $this->age = $age;
+    }
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+}

--- a/tests/Fixtures/TestsFirestore.php
+++ b/tests/Fixtures/TestsFirestore.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Firevel\FirestoreCacheDriver\Fixtures;
+
+use Google\Cloud\Firestore\DocumentSnapshot;
+use Google\Cloud\Firestore\FirestoreClient;
+use PHPUnit\Framework\TestCase as PHPUnit;
+
+trait TestsFirestore
+{
+
+    /**
+     * Test if a given key exists in the Firestore
+     * @param string $key
+     * @param null|string $collection
+     * @param null|string $prefix
+     * @return void
+     */
+    protected function assertFirestoreKeyExists(string $key, ?string $collection = null, ?string $prefix = null): void
+    {
+        PHPUnit::assertTrue(
+            $this->firestoreSnapshot($key, $collection, $prefix)->exists(),
+            "The cache key [[$prefix]-[$key]] could not be found in [[$collection]]"
+        );
+    }
+
+    /**
+     * Test if a given key does not exist in the Firestore
+     * @param string $key
+     * @param null|string $collection
+     * @param null|string $prefix
+     * @return void
+     */
+    protected function assertFirestoreKeyMissing(string $key, ?string $collection = null, ?string $prefix = null): void
+    {
+        PHPUnit::assertFalse(
+            $this->firestoreSnapshot($key, $collection, $prefix)->exists(),
+            "The cache key [[$prefix]-[$key]] could not be found in [[$collection]]"
+        );
+    }
+
+    /**
+     * Checks if a cache value matches the given value
+     * @param mixed $expected
+     * @param string $key
+     * @param null|string $collection
+     * @param null|string $prefix
+     * @return void
+     */
+    protected function assertFirestoreKeyEquals($expected, string $key, ?string $collection = null, ?string $prefix = null): void
+    {
+        $data = $this->firestoreSnapshot($key, $collection, $prefix)->data();
+        $data = $data ? unserialize($data['value']) : null;
+
+        PHPUnit::assertEquals(
+            $expected,
+            $data,
+            "The cache key [[$prefix]-[$key]] in [{$collection}] does not match the value given"
+        );
+    }
+
+    /**
+     * @return null|string
+     */
+    protected function getConfiguredCollection(): ?string
+    {
+        $store = $this->app['config']->get('cache.default');
+        return (string) $this->app['config']->get("cache.stores.{$store}.collection");
+    }
+
+    /**
+     * @return null|string
+     */
+    protected function getConfiguredPrefix(): ?string
+    {
+        return (string) $this->app['config']->get('cache.prefix', '');
+    }
+
+    /**
+     * @return FirestoreClient
+     */
+    private function getFirestore(): FirestoreClient
+    {
+        static $client = null;
+        return $client ?? ($client = new FirestoreClient());
+    }
+
+    /**
+     * @return void
+     */
+    protected function flushFirestore(): void
+    {
+        $this->afterApplicationCreated(function () {
+            $collection = $this->getConfiguredCollection();
+
+            if (!$collection) {
+                return;
+            }
+
+            foreach ($this->getFirestore()->collection($collection)->documents() as $item) {
+                $item->reference()->delete();
+            }
+        });
+    }
+
+    /**
+     * Checks if the number of documents matches the expected count
+     * @param mixed $expected
+     * @param string $key
+     * @param null|string $collection
+     * @param null|string $prefix
+     * @return void
+     */
+    protected function assertFirestoreCount($expected, ?string $collection = null, ?string $prefix = null): void
+    {
+        PHPUnit::assertSame(
+            $expected,
+            $this->firestoreCount($collection, $prefix),
+            "Expected firestore to contain {$expected} documents"
+        );
+    }
+
+    /**
+     * Gets a read-only connection to the given document
+     * @param string $key
+     * @param null|string $collection
+     * @param null|string $prefix
+     * @return DocumentSnapshot
+     */
+    private function firestoreSnapshot(
+        string $key,
+        ?string $collection = null,
+        ?string $prefix = null
+    ): DocumentSnapshot {
+        $collection = $collection ?? $this->getConfiguredCollection();
+        $prefix = $prefix ?? $this->getConfiguredPrefix();
+
+        return $this->getFirestore()
+            ->collection($collection)
+            ->document($prefix . $key)
+            ->snapshot();
+    }
+
+    /**
+     * Returns the number of files matching the given query
+     * @param null|string $collection
+     * @param null|string $prefix
+     * @return int
+     */
+    private function firestoreCount(?string $collection = null, ?string $prefix = null): int
+    {
+        $collection = $collection ?? $this->getConfiguredCollection();
+        $prefix = $prefix ?? $this->getConfiguredPrefix();
+
+        return $this->getFirestore()
+            ->collection($collection)
+            ->where('prefix', '=', $prefix)
+            ->documents()
+            ->size();
+    }
+
+    /**
+     * Dumps the current store contents
+     * @return void
+     */
+    protected function dumpStore(): void
+    {
+        $res = [];
+        foreach ($this->getFirestore()->collection($this->getConfiguredCollection())->documents() as $item) {
+            $key = $item->id();
+            $data = $item->data();
+
+            $res[$key] = $data;
+        }
+
+        dump($res);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,9 +6,23 @@ namespace Tests\Firevel\FirestoreCacheDriver;
 
 use Firevel\FirestoreCacheDriver\FirestoreCacheServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Tests\Firevel\FirestoreCacheDriver\Fixtures\TestsFirestore;
 
 class TestCase extends OrchestraTestCase
 {
+    use TestsFirestore;
+
+    /**
+     * Flush cache on each startup
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->flushFirestore();
+    }
+
     /**
      * Get package providers.
      * @param  \Illuminate\Foundation\Application  $app
@@ -34,5 +48,18 @@ class TestCase extends OrchestraTestCase
             'driver' => 'firestore',
             'collection' => 'testing'
         ]);
+    }
+
+    /**
+     * Helper to set the cache collection and prefix
+     * @param string $collection
+     * @param null|string $prefix
+     * @return void
+     */
+    public function setCollectionAndPrefix(string $collection, ?string $prefix): void
+    {
+        // Update
+        $this->app['config']->set('cache.firestore-test.collection', $collection);
+        $this->app['config']->set('cache.prefix', $prefix);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Firevel\FirestoreCacheDriver;
+
+use Firevel\FirestoreCacheDriver\FirestoreCacheServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+class TestCase extends OrchestraTestCase
+{
+    /**
+     * Get package providers.
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            FirestoreCacheServiceProvider::class
+        ];
+    }
+
+    /**
+     * Define environment setup.
+     * @param  \Illuminate\Foundation\Application   $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $config = $app->make('config');
+        $config->set('cache.default', 'firestore-test');
+        $config->set('cache.stores.firestore-test', [
+            'driver' => 'firestore',
+            'collection' => 'testing'
+        ]);
+    }
+}

--- a/tests/Unit/FirestoreCacheTest.php
+++ b/tests/Unit/FirestoreCacheTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Firevel\FirestoreCacheDriver\Unit;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
+use Tests\Firevel\FirestoreCacheDriver\Fixtures\TestPerson;
+use Tests\Firevel\FirestoreCacheDriver\TestCase;
+
+class FirestoreCacheTest extends TestCase
+{
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     * @dataProvider provideTestData
+     */
+    public function testAssignment(string $key, $value): void
+    {
+        // Make sure missing
+        $this->assertNull(Cache::get($key));
+
+        // Save some data
+        Cache::put($key, $value);
+
+        // Validate it was created equally
+        $this->assertFirestoreKeyExists($key);
+        $this->assertFirestoreKeyEquals($value, $key);
+
+        // Forget it
+        Cache::forget($key);
+        $this->assertFirestoreKeyMissing($key);
+    }
+
+    /**
+     * Check if the caches are pruned when expired keys are pulled
+     * @return void
+     * @dataProvider provideTestData
+     */
+    public function testExpiry(string $key, $value): void
+    {
+        // Create an entry on Dec 1st
+        Date::setTestNow('2020-12-01T00:00:00+00:00');
+        Cache::put($key, $value, now()->addDays(7));
+
+        // Validate it was created
+        $this->assertFirestoreKeyExists($key);
+        $this->assertFirestoreKeyEquals($value, $key);
+
+        // Access the entry on dec 5th
+        Date::setTestNow('2020-12-05T00:00:00+00:00');
+        $this->assertEquals($value, Cache::get($key));
+
+        // Access the entry on dec 8th
+        Date::setTestNow('2020-12-08T00:00:01+00:00');
+        $this->assertNull(Cache::get($key));
+
+        // Validate it was dropped
+        $this->assertFirestoreKeyMissing($key);
+    }
+
+    /**
+     * Check if the keys are removed when expired keys are pulled
+     * @return void
+     * @dataProvider provideTestData
+     */
+    public function testPullMethod(string $key, $value): void
+    {
+        // Create an entry on Dec 1st
+        Cache::put($key, $value);
+
+        // Validate it was created
+        $this->assertFirestoreKeyExists($key);
+        $this->assertFirestoreKeyEquals($value, $key);
+
+        // Pull it and ensure it's removed
+        $this->assertEquals($value, Cache::pull($key));
+        $this->assertFirestoreKeyMissing($key);
+    }
+
+    /**
+     * Checks increments and decrements
+     * @return void
+     */
+    public function testIncrementAndDecrement(): void
+    {
+        $key = 'increase.me';
+        $this->assertFirestoreKeyMissing($key);
+
+        Cache::increment($key);
+        $this->assertFirestoreKeyEquals(1, $key);
+
+        Cache::increment($key, 42);
+        $this->assertFirestoreKeyEquals(1 + 42, $key);
+
+        Cache::decrement($key, 12);
+        $this->assertFirestoreKeyEquals(1 + 42 - 12, $key);
+
+        Cache::decrement($key);
+        $this->assertFirestoreKeyEquals(1 + 42 - 12 - 1, $key);
+
+        Cache::forget($key);
+        Cache::decrement($key);
+        $this->assertFirestoreKeyEquals(-1, $key);
+    }
+
+    /**
+     * Checks increments and decrements
+     * @return void
+     */
+    public function testPutManyAndFlush(): void
+    {
+        $data = array_combine(
+            Arr::pluck($this->provideTestData(), '0'),
+            Arr::pluck($this->provideTestData(), '1')
+        );
+
+        // Store
+        Cache::putMany($data);
+        Cache::put('testputandflus', now());
+
+        // Check
+        foreach ($data as $key => $value) {
+            $this->assertFirestoreKeyEquals($value, $key);
+        }
+
+        // Flush
+        Cache::flush();
+
+        // Check
+        foreach (array_keys($data) as $key) {
+            $this->assertFirestoreKeyMissing($key);
+        }
+    }
+
+    /**
+     * Just provide messy data
+     * @return array
+     */
+    public function provideTestData(): array
+    {
+        return [
+            'string' => ['test', 'yellow'],
+            'array' => ['i am a douche', ['douche' => true]],
+            'object' => ['new-users', new TestPerson('harry', 28)],
+            'emoji' => ['data.😎', '🎆'],
+            'empty' => ['steve', null]
+        ];
+    }
+}

--- a/tests/Unit/FirestoreServiceProviderTest.php
+++ b/tests/Unit/FirestoreServiceProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Firevel\FirestoreCacheDriver\Unit;
+
+use Firevel\FirestoreCacheDriver\FirestoreCache;
+use Illuminate\Support\Facades\Cache;
+use Tests\Firevel\FirestoreCacheDriver\TestCase;
+
+class FirestoreServiceProviderTest extends TestCase
+{
+    public function testStoreDriver(): void
+    {
+        $this->setCollectionAndPrefix('my-collection', 'my-prefix');
+
+        /** @var FirestoreCache $store */
+        $store = Cache::store('firestore-test')->getStore();
+
+        $this->assertInstanceOf(FirestoreCache::class, $store);
+
+        $this->assertSame('my-prefix', $store->getPrefix());
+    }
+}


### PR DESCRIPTION
I made a bunch of changes to make the code more predictable.

- Added `illuminate/contracts`, `illuminate/support` and `php` constraints to `dependencies`
- Added Testbench for unit testing
- Added composer scripts to spin up a Firestore emulator
- 100% test coverage, according to the Support/Cache contract
- Contribution guide on how to run the tests
